### PR TITLE
fix: bump deps for ci

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -9,12 +9,19 @@ _.file = ".env.yaml"
 [tasks.bump-deps]
 description = "update all dependencies"
 run = '''
+  echo "Saving current go version"
+  current_go_version=$(mise ls -cl go --json | jq -r '.[].version')
+  echo "Current go version is ${current_go_version}"
   echo "Updating all dependencies..."
   mise up
   echo "Removing go.mod go.sum entries for 'go' directive..."
   sed -i "/^go .*/d" go.mod
   echo "Re-installing tools..."
   mise install
+  echo "Updating GOROOT"
+  new_go_version=$(mise ls -cl go --json | jq -r '.[].version')
+  export GOROOT=$(echo "${goroot}" | sed s'/$current_go_version/$new_go_version/')
+  echo "New GOROOT is ${GOROOT}"
   echo "Updating go.mod and go.sum files..."
   go get -u ./...
   echo "Cleaning up go.mod and go.sum files..."


### PR DESCRIPTION
Re-export GOROOT after mise up to fix go command not found
